### PR TITLE
fix `it` -> `is` typo

### DIFF
--- a/presto/serverprivate.nim
+++ b/presto/serverprivate.nim
@@ -148,7 +148,7 @@ proc processRestRequest*[T](server: T,
                error_name = $exc.name
           return dumbResponse()
       else:
-        debug "Request it not part of api", peer = $request.remoteAddress(),
+        debug "Request is not part of API", peer = $request.remoteAddress(),
               meth = $request.meth, uri = $request.uri
         return await request.respond(Http404, "", HttpTable.init())
     else:


### PR DESCRIPTION
This fixes a minor typo in the log message `Request it not part of api`
and changes the `api` to uppercase for consistency with the other logs.