### PR TITLE
Allow the 'api' macro to be used in generic functions

### DIFF
--- a/presto/route.nim
+++ b/presto/route.nim
@@ -210,8 +210,7 @@ proc processApiCall(router: NimNode, meth: HttpMethod,
       for paramName, paramType in parameters.paramsIter():
         let index = patterns.find($paramName)
         if isPathArg(paramType):
-          if isSimpleType(paramType) and
-             (paramType.strVal == "HttpResponseRef"):
+          if paramType.isKnownType("HttpResponseRef"):
             if isNil(respRes):
               respRes = paramName
             else:
@@ -257,7 +256,7 @@ proc processApiCall(router: NimNode, meth: HttpMethod,
     error("Return value must not be empty and equal to [RestApiResponse]",
            parameters)
   else:
-    if returnType.strVal != "RestApiResponse":
+    if not returnType.isKnownType("RestApiResponse"):
       error("Return value must be equal to [RestApiResponse]", returnType)
 
   # "path" (required) arguments unmarshalling code.


### PR DESCRIPTION
The type equivalence approach taken by the library is very fragile and easy to break with Nim features such as type aliases and others, but this makes some improvements that at least allow trivial usages of the library in generic functions.