### PR TITLE
add missing imports

### DIFF
--- a/presto/segpath.nim
+++ b/presto/segpath.nim
@@ -7,7 +7,7 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import std/[uri, strutils]
-import stew/bitops2
+import stew/[bitops2, results]
 import chronos/apps
 import common
 export common, apps
@@ -88,11 +88,11 @@ proc getPairs*(spath: SegmentedPath, vpath: SegmentedPath): seq[KeyValueTuple] =
     res.add(item)
   res
 
-proc getValue(data: seq[KeyValueTuple], key: string): Option[string] =
+proc getValue(data: seq[KeyValueTuple], key: string): Opt[string] =
   for item in data:
     if item.key == key:
-      return some(item.value)
-  return none[string]()
+      return Opt.some(item.value)
+  return Opt.none(string)
 
 proc rewritePath*(spath: SegmentedPath, dpath: SegmentedPath,
                   vpath: SegmentedPath): SegmentedPath =

--- a/presto/servercommon.nim
+++ b/presto/servercommon.nim
@@ -6,9 +6,10 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
+import std/options
 import chronicles
 import common
-export chronicles
+export chronicles, options
 
 chronicles.formatIt(HttpTable):
   var res = newSeq[string]()


### PR DESCRIPTION
`options` no longer exported by chronos