### PR TITLE
Remove `connection` field from logging statements.

### DIFF
--- a/presto/secureserver.nim
+++ b/presto/secureserver.nim
@@ -6,7 +6,7 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import std/[options, strutils]
+import std/options
 import chronos, chronos/apps/http/shttpserver
 import chronicles
 import stew/results


### PR DESCRIPTION
* Remove `connection` field from logging statements.
* Keep `address` field first.
* Fix warnings generated by macro usage.
* Fix strutils warning.