### PR TITLE
reduce imports

### DIFF
--- a/presto/common.nim
+++ b/presto/common.nim
@@ -6,9 +6,10 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import chronos/apps, chronos/apps/http/httpclient
+import chronos/apps/http/httptable
 import stew/[results, byteutils], httputils
-export results, apps, httputils
+
+export results, httputils, httptable
 
 {.push raises: [Defect].}
 


### PR DESCRIPTION
not needed, cause both http(s) server and client to be compiled unnecessarily for any presto usage, including bearssl