### PR TITLE
add response duration metric historgram with buckets

### DIFF
--- a/presto/serverprivate.nim
+++ b/presto/serverprivate.nim
@@ -29,6 +29,12 @@ when defined(metrics):
                "Time taken to prepare response",
                labels = ["endpoint"]
 
+  declareHistogram presto_server_prepare_response_duration_seconds,
+                   "Histogram of HTTP response preparation duration, in seconds",
+                   labels = ["endpoint"],
+                   buckets = [0.01, 0.025, 0.05, 0.1, 0.25,
+                              0.5, 1, 2.5, 5, 10, Inf]
+
 proc getContentBody*(r: HttpRequestRef): Future[Option[ContentBody]] {.
      async: (raises: [CancelledError, HttpTransportError, HttpProtocolError,
                       RestBadRequestError]).} =
@@ -80,12 +86,18 @@ when defined(metrics):
       let endpoint = $route.routePath
       presto_server_prepare_response_time.set(duration.milliseconds(),
                                               @[endpoint])
+      let seconds = float64(duration.milliseconds()) / 1000.0
+      presto_server_prepare_response_duration_seconds.observe(seconds,
+                                                             @[endpoint])
 
   proc processMetrics(route: RestRoute, duration: Duration) =
     if RestServerMetricsType.Response in route.metrics:
       let endpoint = $route.routePath
       presto_server_prepare_response_time.set(duration.milliseconds(),
                                               @[endpoint])
+      let seconds = float64(duration.milliseconds()) / 1000.0
+      presto_server_prepare_response_duration_seconds.observe(seconds,
+                                                             @[endpoint])
 
 proc processRestRequest*[T](
        server: T,


### PR DESCRIPTION
This way we can measure spread of latencies across multiple requests over time and not just duration time of the last request made.

Example:
```
# HELP presto_server_prepare_response_duration_seconds Histogram of HTTP response preparation duration, in seconds
# TYPE presto_server_prepare_response_duration_seconds histogram
presto_server_prepare_response_duration_seconds_sum{endpoint="GET/eth/v1/beacon/states/{state_id}/fork"} 1.028
presto_server_prepare_response_duration_seconds_count{endpoint="GET/eth/v1/beacon/states/{state_id}/fork"} 6.0
presto_server_prepare_response_duration_seconds_created{endpoint="GET/eth/v1/beacon/states/{state_id}/fork"} 1777402883.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="0.01"} 4.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="0.025"} 4.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="0.05"} 4.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="0.1"} 4.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="0.25"} 4.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="0.5"} 5.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="1.0"} 6.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="2.5"} 6.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="5.0"} 6.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="10.0"} 6.0
presto_server_prepare_response_duration_seconds_bucket{endpoint="GET/eth/v1/beacon/states/{state_id}/fork",le="+Inf"} 6.0
```

Personally I think `presto_server_prepare_response_time` metric is almost useless because high latency responses can be easily lost because the next `set()` call can reset the value back to a normal looking one.

Removing it entirely might be even better. Happy to do that if people agree.