### PR TITLE
replace response duration gauge with incremental counters

### DIFF
--- a/presto/serverprivate.nim
+++ b/presto/serverprivate.nim
@@ -16,15 +16,15 @@ import "."/[route, common, segpath, servercommon]
 when defined(metrics):
   import metrics
 
-  declareGauge presto_server_response_status_count,
-               "Number of HTTP server responses with specific status",
-               labels = ["endpoint", "status"]
-  declareGauge presto_server_processed_request_count,
-               "Number of HTTP(s) processed requests"
-  declareGauge presto_server_missing_requests_count,
-               "Number of HTTP(s) requests to unrecognized API endpoints"
-  declareGauge presto_server_invalid_requests_count,
-               "Number of HTTP(s) requests invalid API endpoints"
+  declareCounter presto_server_responses,
+                 "Number of HTTP server responses with specific status",
+                 labels = ["endpoint", "status"]
+  declareCounter presto_server_processed_requests,
+                 "Number of HTTP(s) processed requests"
+  declareCounter presto_server_missing_requests,
+                 "Number of HTTP(s) requests to unrecognized API endpoints"
+  declareCounter presto_server_invalid_requests,
+                 "Number of HTTP(s) requests invalid API endpoints"
   declareCounter presto_server_prepare_responses,
                  "Number of prepared responses",
                  labels = ["endpoint"]
@@ -79,7 +79,7 @@ when defined(metrics):
       let
         endpoint = $route.routePath
         scode = Base10.toString(uint64(toInt(code)))
-      presto_server_response_status_count.inc(1, @[endpoint, scode])
+      presto_server_responses.inc(1, @[endpoint, scode])
 
   proc processStatusMetrics(route: RestRoute, code: HttpCode,
                             duration: Duration) =
@@ -139,7 +139,7 @@ proc processRestRequest*[T](
               meth = $request.meth, uri = $request.uri
 
         when defined(metrics):
-          presto_server_invalid_requests_count.inc()
+          presto_server_invalid_requests.inc()
 
         sresponse(request, Http400, RestRequestError.Invalid)
 
@@ -156,7 +156,7 @@ proc processRestRequest*[T](
               peer = $request.remoteAddress(), uri = $request.uri
 
         when defined(metrics):
-          presto_server_missing_requests_count.inc()
+          presto_server_missing_requests.inc()
 
         sresponse(request, Http404, RestRequestError.NotFound)
   let
@@ -165,7 +165,7 @@ proc processRestRequest*[T](
     queryParams = request.query
 
   when defined(metrics):
-    presto_server_processed_request_count.inc()
+    presto_server_processed_requests.inc()
 
   let optBody =
     if RestRouterFlag.Raw notin route.flags:

--- a/presto/serverprivate.nim
+++ b/presto/serverprivate.nim
@@ -25,9 +25,12 @@ when defined(metrics):
                "Number of HTTP(s) requests to unrecognized API endpoints"
   declareGauge presto_server_invalid_requests_count,
                "Number of HTTP(s) requests invalid API endpoints"
-  declareGauge presto_server_prepare_response_time,
-               "Time taken to prepare response",
-               labels = ["endpoint"]
+  declareCounter presto_server_prepare_responses,
+                 "Number of prepared responses",
+                 labels = ["endpoint"]
+  declareCounter presto_server_prepare_response_duration_seconds,
+                 "Total time taken to prepare responses",
+                 labels = ["endpoint"]
 
 proc getContentBody*(r: HttpRequestRef): Future[Option[ContentBody]] {.
      async: (raises: [CancelledError, HttpTransportError, HttpProtocolError,
@@ -65,6 +68,12 @@ proc mergeHttpHeaders(a: var HttpTable, b: HttpTable) =
         a.add(key, item)
 
 when defined(metrics):
+  proc processResponseMetrics(route: RestRoute, duration: Duration) =
+    let endpoint = $route.routePath
+    presto_server_prepare_responses.inc(1, @[endpoint])
+    presto_server_prepare_response_duration_seconds.inc(
+      float64(duration.milliseconds()) / 1000.0, @[endpoint])
+
   proc processStatusMetrics(route: RestRoute, code: HttpCode) =
     if RestServerMetricsType.Status in route.metrics:
       let
@@ -77,15 +86,11 @@ when defined(metrics):
     if RestServerMetricsType.Status in route.metrics:
       processStatusMetrics(route, code)
     if RestServerMetricsType.Response in route.metrics:
-      let endpoint = $route.routePath
-      presto_server_prepare_response_time.set(duration.milliseconds(),
-                                              @[endpoint])
+      processResponseMetrics(route, duration)
 
   proc processMetrics(route: RestRoute, duration: Duration) =
     if RestServerMetricsType.Response in route.metrics:
-      let endpoint = $route.routePath
-      presto_server_prepare_response_time.set(duration.milliseconds(),
-                                              @[endpoint])
+      processResponseMetrics(route, duration)
 
 proc processRestRequest*[T](
        server: T,


### PR DESCRIPTION
The `presto_server_prepare_response_time` metric is almost useless because high latency responses can be easily lost because the next `set()` call can reset the value back to a normal looking one.

With the incremental counters we can detect duration spikes and combine both in a query to get mean response duration over last 5 minutes with:
```promql
rate(presto_server_prepare_response_duration_seconds_total[5m])
/ rate(presto_server_prepare_responses_total[5m])
```
Also changed server gauges to counters since we increment these metrics:
```
presto_server_response_status_count   > presto_server_responses_total
presto_server_processed_request_count > presto_server_processed_requests_total
presto_server_missing_requests_count  > presto_server_missing_requests_total
presto_server_invalid_requests_count  > presto_server_invalid_requests_total
``` 
Dropped the 'count' part since it seemed redundant in the name.

Simplified less verbose metrics as compared to historgram proposed in:

- https://github.com/status-im/nim-presto/pull/92